### PR TITLE
Fix type equality check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ script:
 - sbt "test"
 - sbt "scalafmtTest"
 before_install:
-- openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in secring.gpg.enc -out local.secring.gpg
-  -d
-- openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in pubring.gpg.enc -out local.pubring.gpg
-  -d
-- openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in credentials.sbt.enc -out
-  local.credentials.sbt -d
+- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in secring.gpg.enc -out local.secring.gpg
+  -d; fi
+- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in pubring.gpg.enc -out local.pubring.gpg
+  -d; fi
+- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in credentials.sbt.enc -out
+  local.credentials.sbt -d; fi
 after_success:
 - '[ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ] && /bin/bash
   sbt "publishSigned"'

--- a/examples/src/test/scala/com/rouesnel/typedsql/examples/TypeInferenceExample.scala
+++ b/examples/src/test/scala/com/rouesnel/typedsql/examples/TypeInferenceExample.scala
@@ -1,0 +1,19 @@
+package com.rouesnel.typedsql
+package examples
+
+
+//An example of a structure that does not compile with abstract classes inside
+//CompiledSqlQuery but does with abstract types. Not asserting anything at
+//runtime, just verifying compilation
+
+abstract class TypedSqlFeatureSet[S <: CompiledSqlQuery](s: S) extends FeatureSet[S#Row]
+trait Feature[S]
+trait FeatureSet[S]  {
+  def features: Iterable[Feature[S]]
+}
+
+object Step1FeatureSet extends TypedSqlFeatureSet(Step1) {
+  val feat1: Feature[Step1.Row] = ???
+
+  def features = List(feat1)
+}

--- a/macro/src/main/scala/com/rouesnel/typedsql/CompiledSqlQuery.scala
+++ b/macro/src/main/scala/com/rouesnel/typedsql/CompiledSqlQuery.scala
@@ -11,11 +11,11 @@ trait CompiledSqlQuery {
   def partitions: List[(String, String)] = Nil
 
   /** Source datasets inside the query */
-  abstract class Sources
+  type Sources
 
   /** Configuration parameters available inside the query */
-  abstract class Parameters
+  type Parameters
 
   /** Output type for each row returned by the query */
-  abstract class Row extends ThriftStruct
+  type Row <: ThriftStruct
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,4 +1,4 @@
-version in ThisBuild := "0.3.0"
+version in ThisBuild := "0.3.1"
 
 licenses in ThisBuild := Seq(
   "Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")


### PR DESCRIPTION
Fix type equality check to run correctly when referring to an abstract Row.

Don't know why this works really, but it does,
